### PR TITLE
Remove dependencies for media_flickr module.

### DIFF
--- a/d7.make
+++ b/d7.make
@@ -71,7 +71,6 @@ projects[media][type] = "module"
 projects[media_youtube][type] = "module"
 projects[media_vimeo][type] = "module"
 projects[media_soundcloud][type] = "module"
-projects[media_flickr][type] = "module"
 
 
 ; Themes

--- a/profiles/quilted_profile/quilted_profile.info
+++ b/profiles/quilted_profile/quilted_profile.info
@@ -52,7 +52,6 @@ dependencies[] = file_entity
 dependencies[] = media_youtube
 dependencies[] = media_vimeo
 dependencies[] = media_soundcloud
-dependencies[] = media_flickr
 
 dependencies[] = quilted_dev
 


### PR DESCRIPTION
I think the install script is choking on the way the module lists it's supported versions.

I made an issue: #10
